### PR TITLE
Make a Dockerfile with a very slim output image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM clux/muslrust
+FROM clux/muslrust as builder
 
 RUN rustup update stable \
  && rustup default stable \
  && rustup target add x86_64-unknown-linux-musl \
  && cargo install cargo-deb tomato-toml
 
-COPY entrypoint.sh /entrypoint.sh
+FROM alpine:3.16 as runner
+
+COPY --from=builder /root/.cargo/bin/cargo-deb /cargo-deb
+COPY --from=builder /root/.cargo/bin/tomato /tomato
+COPY /entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,9 @@ else
     VERSION=$(echo "$GITHUB_REF" | sed 's|refs/tags/||')
 fi
 
-tomato set package.version "$VERSION" "$INPUT_TOML_PATH/Cargo.toml"
+PATH=$PATH:/
+
+./tomato set package.version "$VERSION" "$INPUT_TOML_PATH/Cargo.toml"
 
 # Taken from https://github.com/zhxiaogg/cargo-static-build, unsure if all needed or not
 


### PR DESCRIPTION
Problem to solve: The current build process spends quite a long time building an entire rust build chain to install the cargo-deb and tomato executables.  We build this image every single time we do a build.

Solution: Prebuild a very slender docker image with cargo-deb and tomato executables and pull the image as needed during builds.